### PR TITLE
Fixed merge balls above the line

### DIFF
--- a/lib/game.js
+++ b/lib/game.js
@@ -198,7 +198,7 @@ const game = (getBallLevel, sleepFunction, gameBoard) => {
         map[d.x >= 6 ? 6 : d.x + 1][d.y],
         map[d.x <= 0 ? 0 : d.x - 1][d.y],
         map[d.x][d.y >= 6 ? 6 : d.y + 1],
-        map[d.x][d.y <= -1 ? -1 : d.y - 1]
+        map[d.x][d.y <= -2 ? -2 : d.y - 1]
       ]
         .filter(n => n && n.type === d.type && n.key !== d .key)
         .reduce((l, d) => l.concat(checkTile(d)), [d])


### PR DESCRIPTION
Hi, first of all, thanks for the implementation. I loved this game back in the day and seeing it again with the open code was such a pleasure. 

I noticed ball merging was behaving weirdly when the balls were above the game over line, ie placing two dots vertical above one just below the line like: 

Blue
Red
------
Red 

would make the two reds merge into pink and the blue disappear. 

It is my first javascript contribution to any code and I could not understand how to define boards for the tests, if you can give me a pointer I can add some tests as well. 